### PR TITLE
use R/get_conf.r for mpi flags

### DIFF
--- a/configure
+++ b/configure
@@ -1748,8 +1748,8 @@ if test "X$CDEFS" = "X-D" ; then
   CDEFS_CHECK=FALSE
 fi
 
-SPMD_CPPFLAGS=`${R_SCMD} "pbdMPI::get.conf('PKG_CPPFLAGS','"${R_ARCH}"','pbdMPI')"`
-SPMD_LDFLAGS=`${R_SCMD} "pbdMPI::get.conf('PKG_LIBS','"${R_ARCH}"','pbdMPI')"`
+SPMD_CPPFLAGS=`${R_SCMD} "source('./R/get_conf.r');get.conf('PKG_CPPFLAGS','"${R_ARCH}"')"`
+SPMD_LDFLAGS=`${R_SCMD} "source('./R/get_conf.r');get.conf('PKG_LIBS','"${R_ARCH}"')"`
 
 
 echo " "

--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,8 @@ if test "X$CDEFS" = "X-D" ; then
 fi
 
 dnl pbdMPI
-SPMD_CPPFLAGS=`${R_SCMD} "pbdMPI::get.conf('PKG_CPPFLAGS','"${R_ARCH}"','pbdMPI')"`
-SPMD_LDFLAGS=`${R_SCMD} "pbdMPI::get.conf('PKG_LIBS','"${R_ARCH}"','pbdMPI')"`
+SPMD_CPPFLAGS=`${R_SCMD} "source('./R/get_conf.r');get.conf('PKG_CPPFLAGS','"${R_ARCH}"')"`
+SPMD_LDFLAGS=`${R_SCMD} "source('./R/get_conf.r');get.conf('PKG_LIBS','"${R_ARCH}"')"`
 
 
 dnl Report


### PR DESCRIPTION
We need this for OLCF machines because MPI processes get killed unless launched with `mpirun`.